### PR TITLE
Added checks for service_at_location and email in contact information

### DIFF
--- a/ServiceFinder/src/components/sections/Services/Contact-infoService.jsx
+++ b/ServiceFinder/src/components/sections/Services/Contact-infoService.jsx
@@ -6,17 +6,21 @@ export default class ContactInfoComponent extends React.Component {
         return (
             <>
                 <InfoServiceSection title="Contact">
-                    {this.props.data.contacts.length > 0 ?
-                        <div>
-                            <h5>Contact tel: </h5>
-                            <ul>
-                                {this.props.data.contacts.map((item, i) => (
-                                    item.phones.map(itemPhone => (
-                                        <li className="mb-0" key={i}>{itemPhone.number}</li>
-                                    ))
+                    {this.props.data.contacts.length > 0 || this.props.data.service_at_locations.length > 0 || this.props.data.email !== '' ?
 
-                                ))}
-                            </ul>
+                        <div>
+                            {this.props.data.contacts.length > 0 &&
+                                <>
+                                    <h5>Contact tel: </h5>
+                                    <ul>
+                                        {this.props.data.contacts.map((item, i) => (
+                                            item.phones.map(itemPhone => (
+                                            <li className="mb-0" key={i}>{itemPhone.number}</li>
+                                            ))
+                                        ))}
+                                    </ul>
+                                </>
+                            }
                             {this.props.data.email !== '' &&
                                 <>
                                     <h5>Contact email:</h5>

--- a/ServiceFinder/src/components/shared/Components/ResultModal.jsx
+++ b/ServiceFinder/src/components/shared/Components/ResultModal.jsx
@@ -122,17 +122,20 @@ class ResultModal extends React.Component {
                                         <div className="contact sticky-top">
                                             <h4>Contact</h4>
                                             <hr />
-                                            {this.props.data.contacts.length > 0 ?
+                                            {this.props.data.contacts.length > 0 || this.props.data.service_at_locations.length > 0 || this.props.data.email !== '' ?
                                                 <div>
-                                                    <h5>Contact tel: </h5>
-                                                    <ul>
-                                                        {this.props.data.contacts.map((item, i) => (
-                                                            item.phones.map(itemPhone => (
-                                                                <li className="mb-0" key={i}>{itemPhone.number}</li>
-                                                            ))
-
-                                                        ))}
-                                                    </ul>
+                                                    {this.props.data.contacts.length > 0 &&
+                                                    <>
+                                                        <h5>Contact tel: </h5>
+                                                        <ul>
+                                                            {this.props.data.contacts.map((item, i) => (
+                                                                item.phones.map(itemPhone => (
+                                                                    <li className="mb-0" key={i}>{itemPhone.number}</li>
+                                                                ))
+                                                            ))}
+                                                        </ul>
+                                                    </>
+                                                    }
                                                     {this.props.data.email !== '' &&
                                                         <>
                                                             <h5>Contact email:</h5>


### PR DESCRIPTION
Added a check for email and service_at_locations in contact views, as if the service does not have a telephone number the other contact information would not be shown.

Example:
[/service/00ca0f29-1bbd-431b-b81d-6b1be3cef6ba](https://lgademo2.vidavia.net/service/00ca0f29-1bbd-431b-b81d-6b1be3cef6ba)
![image](https://user-images.githubusercontent.com/55835325/71809624-60622c00-3068-11ea-8ce1-5477a7b5a6ec.png)
Fix:
![image](https://user-images.githubusercontent.com/55835325/71809674-77a11980-3068-11ea-8229-121c48ae47ec.png)
